### PR TITLE
Updated flexibility, `begin` NOT BACKWARDS COMPATIBLE

### DIFF
--- a/Maxbotix.h
+++ b/Maxbotix.h
@@ -34,33 +34,27 @@ Distributed as-is; no warranty is given.
 class Maxbotix
 {
 	public:
-		Maxbotix();
-		bool begin(uint8_t _RxPin, uint8_t _nPings=1, bool _writeAll=false, \
-               uint8_t _ExPin=-1, bool _RS232=false, \
-               uint16_t _minRange_mm=501, uint16_t _maxRange_mm=4999);
+		Maxbotix(uint8_t DataPin = -1);
+		bool begin(uint8_t _nPings=1, bool _writeAll=false, \
+               uint8_t _ExPin=-1);
 		// bool begin(uint8_t _RxPin);
 		int16_t GetRange();
 		String GetHeader();
 		String GetString();
 
 	private:
-
-		uint8_t RxPin; // need not be global
 		uint8_t nPings = 1; //Fix??
 		bool writeAll;
 		uint8_t ExPin;
-		bool RS232;
-		uint16_t minRange_mm;
-		uint16_t maxRange_mm;
 
 		uint16_t ranges[10] = {0}; //Fix hard code! and global??
 
     SoftwareSerial softSerial;  //Fix hardcode!
 		// extern SoftwareSerial softSerial;
     void serialBufferClear();
-    int32_t sum(int16_t values[], uint8_t nvalues, bool errorNegative=true);
-    float mean(int16_t values[], uint8_t nvalues, bool errorNegative=true);
-    float standardDeviation(int16_t values[], uint8_t nvalues, float mean, \
+    int32_t sum(uint16_t values[], uint8_t nvalues, bool errorNegative=true);
+    float mean(uint16_t values[], uint8_t nvalues, bool errorNegative=true);
+    float standardDeviation(uint16_t values[], uint8_t nvalues, float mean, \
                             bool errorNegative=true);
 		
 };


### PR DESCRIPTION
Updated system for pin mode variability to support Margay > v2.0 and  more generic systems. Change resulted in loss of backwards compatibility of `begin()` function with previous versions (which did not work for variable pin usage anyway...)

Also fixed stale read issue by forcing definition of `_tmpchar = NULL`